### PR TITLE
Add role-based hospital management system

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ This is a **learning** repository. You will see that the `github-learning-lab` b
 
 We hope you are excited to get started! Head over to the take your first steps toward a :sparkles: Open Source program for your company.
 
+## Hospital Management System
+
+This repository now contains a simple, in-memory hospital management system that models role-based access control across key
+units such as Records, Revenue, Accounts, Nursing, Wards, Maternity, Eye, Adolescent Reproductive Health, Mental Health,
+Family Planning, Laboratory, Pharmacy, Dispensary, and Doctors/Prescribers.
+
+### Features
+- Role-aware permissions for administrative and clinical units
+- Patient registration and visit tracking
+- Service and medication capture with unit ownership
+- Invoice creation and payment recording with revenue summaries by unit
+
+### Quick start
+Run the demonstration script to see a complete workflow:
+
+```bash
+python -m hospital_management.demo
+```
+
+Run automated tests with:
+
+```bash
+python -m pytest
+```
+
 ## License
 
 This repository is licensed under [CC-BY-4.0](../LICENSE) (c) 2019 GitHub, Inc.

--- a/hospital_management/__init__.py
+++ b/hospital_management/__init__.py
@@ -1,0 +1,17 @@
+"""Hospital management system package."""
+
+from .models import Role, Unit, UnitType, User, Patient, Visit, Invoice, MedicationOrder, Service
+from .system import HospitalManagementSystem
+
+__all__ = [
+    "Role",
+    "Unit",
+    "UnitType",
+    "User",
+    "Patient",
+    "Visit",
+    "Invoice",
+    "MedicationOrder",
+    "Service",
+    "HospitalManagementSystem",
+]

--- a/hospital_management/access.py
+++ b/hospital_management/access.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, Set
+
+from .models import Role, UnitType
+
+
+class AccessControl:
+    """Simple role-based access control for hospital units."""
+
+    def __init__(self, policy: Mapping[UnitType, Iterable[Role]]) -> None:
+        self.policy: Dict[UnitType, Set[Role]] = {unit: set(roles) for unit, roles in policy.items()}
+
+    def can_access(self, role: Role, unit: UnitType) -> bool:
+        allowed_roles = self.policy.get(unit, set())
+        return role in allowed_roles or Role.ADMIN in allowed_roles and role == Role.ADMIN
+
+    def assert_access(self, role: Role, unit: UnitType) -> None:
+        if not self.can_access(role, unit):
+            raise PermissionError(f"Role {role.name} cannot access {unit.value}")

--- a/hospital_management/demo.py
+++ b/hospital_management/demo.py
@@ -1,0 +1,68 @@
+"""Demonstration script for the hospital management system."""
+
+from datetime import datetime
+
+from .models import Patient, Role, User, UnitType
+from .system import HospitalManagementSystem
+
+
+def build_demo_system() -> HospitalManagementSystem:
+    system = HospitalManagementSystem.with_default_policy()
+
+    system.add_user(User(user_id="admin1", name="Alice", role=Role.ADMIN))
+    system.add_user(User(user_id="doc1", name="Dr. Kim", role=Role.DOCTOR))
+    system.add_user(User(user_id="nurse1", name="Nurse Lee", role=Role.NURSE))
+    system.add_user(User(user_id="pharm1", name="Pharmacist Jones", role=Role.PHARMACIST))
+    system.add_user(User(user_id="acct1", name="Accountant Sam", role=Role.ACCOUNTANT))
+    system.add_user(User(user_id="clerk1", name="Records Clerk", role=Role.RECORDS_CLERK))
+
+    patient = Patient(patient_id="p001", name="Jamie Doe", date_of_birth=datetime(1990, 5, 1))
+    system.register_patient(patient)
+
+    visit = system.start_visit(visit_id="v001", patient_id=patient.patient_id, user_id="clerk1")
+    system.record_service(visit.visit_id, description="Triage and vitals", unit=UnitType.NURSING, cost=20.0, user_id="nurse1")
+    system.record_service(visit.visit_id, description="Eye screening", unit=UnitType.EYE, cost=45.0, user_id="doc1")
+    system.record_service(
+        visit.visit_id, description="Family planning counseling", unit=UnitType.FAMILY_PLANNING, cost=30.0, user_id="doc1"
+    )
+    system.record_medication(
+        visit.visit_id,
+        medication="Prenatal vitamins",
+        dosage="1 tablet daily",
+        quantity=30,
+        unit=UnitType.PHARMACY,
+        cost=12.0,
+        user_id="pharm1",
+    )
+
+    invoice = system.create_invoice(invoice_id="inv-001", visit_id=visit.visit_id, user_id="acct1")
+    system.record_payment(invoice.invoice_id, amount=50.0, user_id="acct1")
+
+    return system
+
+
+def main() -> None:
+    system = build_demo_system()
+
+    print("Units:", ", ".join(system.list_units()))
+    print("Roles:", ", ".join(system.list_roles()))
+
+    summary = system.get_visit_summary("v001")
+    print("\nVisit Summary")
+    for key, value in summary.items():
+        print(f"- {key}: {value}")
+
+    print("\nRevenue by unit:")
+    for unit in (UnitType.NURSING, UnitType.EYE, UnitType.FAMILY_PLANNING, UnitType.PHARMACY):
+        report = system.report_by_unit(unit)
+        print(f"- {report['unit']}: ${report['total_revenue']} from {report['services_rendered']} services")
+
+    invoice = system.invoices["inv-001"]
+    print("\nInvoice status:")
+    print(f"- Total due: ${invoice.total_due}")
+    print(f"- Balance: ${invoice.balance}")
+    print(f"- Paid: {invoice.paid}")
+
+
+if __name__ == "__main__":
+    main()

--- a/hospital_management/models.py
+++ b/hospital_management/models.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum, auto
+from typing import Dict, List, Set
+
+
+class Role(Enum):
+    """Supported staff roles with different permissions."""
+
+    ADMIN = auto()
+    DOCTOR = auto()
+    NURSE = auto()
+    PHARMACIST = auto()
+    LAB_TECH = auto()
+    ACCOUNTANT = auto()
+    RECORDS_CLERK = auto()
+
+
+class UnitType(Enum):
+    """Clinical and administrative units within the hospital."""
+
+    RECORDS = "Records"
+    REVENUE = "Revenue"
+    ACCOUNTS = "Accounts"
+    NURSING = "Nurses"
+    WARDS = "Wards"
+    MATERNITY = "Maternity"
+    EYE = "Eye"
+    ADOLESCENT_HEALTH = "Adolescent Reproductive Health"
+    MENTAL_HEALTH = "Mental Health"
+    FAMILY_PLANNING = "Family Planning"
+    LABORATORY = "Laboratory"
+    PHARMACY = "Pharmacy"
+    DISPENSARY = "Dispensary"
+    DOCTORS = "Doctors / Prescribers"
+
+
+@dataclass
+class User:
+    """System user with a role used for access control."""
+
+    user_id: str
+    name: str
+    role: Role
+    assigned_units: Set[UnitType] = field(default_factory=set)
+
+
+@dataclass
+class Unit:
+    """Represents an operational unit in the hospital."""
+
+    unit_type: UnitType
+    name: str
+    services: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Patient:
+    """Basic patient record."""
+
+    patient_id: str
+    name: str
+    date_of_birth: datetime
+    demographics: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class Service:
+    """Clinical or administrative service provided to a patient."""
+
+    description: str
+    unit: UnitType
+    cost: float
+
+
+@dataclass
+class MedicationOrder:
+    """Medication request placed by a prescriber and filled by pharmacy or dispensary."""
+
+    medication: str
+    dosage: str
+    quantity: int
+    unit: UnitType
+    cost: float
+
+
+@dataclass
+class Visit:
+    """Represents a patient visit across units."""
+
+    visit_id: str
+    patient: Patient
+    started_at: datetime = field(default_factory=datetime.utcnow)
+    services: List[Service] = field(default_factory=list)
+    medications: List[MedicationOrder] = field(default_factory=list)
+
+    def total_cost(self) -> float:
+        return sum(service.cost for service in self.services) + sum(order.cost for order in self.medications)
+
+
+@dataclass
+class Invoice:
+    """Billing record for a visit."""
+
+    invoice_id: str
+    visit: Visit
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    paid: bool = False
+    payments: List[float] = field(default_factory=list)
+
+    @property
+    def total_due(self) -> float:
+        return self.visit.total_cost()
+
+    @property
+    def balance(self) -> float:
+        return self.total_due - sum(self.payments)
+
+    def add_payment(self, amount: float) -> None:
+        if amount < 0:
+            raise ValueError("Payment amount cannot be negative")
+        self.payments.append(amount)
+        self.paid = self.balance <= 0

--- a/hospital_management/system.py
+++ b/hospital_management/system.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from .access import AccessControl
+from .models import Invoice, MedicationOrder, Patient, Role, Service, Unit, UnitType, User, Visit
+
+
+@dataclass
+class HospitalManagementSystem:
+    """In-memory hospital management system with role-based access control."""
+
+    access_control: AccessControl
+    users: Dict[str, User] = field(default_factory=dict)
+    units: Dict[UnitType, Unit] = field(default_factory=dict)
+    patients: Dict[str, Patient] = field(default_factory=dict)
+    visits: Dict[str, Visit] = field(default_factory=dict)
+    invoices: Dict[str, Invoice] = field(default_factory=dict)
+
+    def add_user(self, user: User) -> None:
+        self.users[user.user_id] = user
+
+    def register_unit(self, unit: Unit) -> None:
+        self.units[unit.unit_type] = unit
+
+    def register_patient(self, patient: Patient) -> None:
+        self.patients[patient.patient_id] = patient
+
+    def start_visit(self, visit_id: str, patient_id: str, user_id: str) -> Visit:
+        user = self.users[user_id]
+        self.access_control.assert_access(user.role, UnitType.RECORDS)
+        patient = self.patients[patient_id]
+        visit = Visit(visit_id=visit_id, patient=patient)
+        self.visits[visit_id] = visit
+        return visit
+
+    def record_service(self, visit_id: str, description: str, unit: UnitType, cost: float, user_id: str) -> Service:
+        user = self.users[user_id]
+        self.access_control.assert_access(user.role, unit)
+        visit = self.visits[visit_id]
+        service = Service(description=description, unit=unit, cost=cost)
+        visit.services.append(service)
+        return service
+
+    def record_medication(
+        self, visit_id: str, medication: str, dosage: str, quantity: int, unit: UnitType, cost: float, user_id: str
+    ) -> MedicationOrder:
+        user = self.users[user_id]
+        if unit not in (UnitType.PHARMACY, UnitType.DISPENSARY):
+            raise ValueError("Medication must be recorded in Pharmacy or Dispensary units")
+        self.access_control.assert_access(user.role, unit)
+        visit = self.visits[visit_id]
+        order = MedicationOrder(medication=medication, dosage=dosage, quantity=quantity, unit=unit, cost=cost)
+        visit.medications.append(order)
+        return order
+
+    def create_invoice(self, invoice_id: str, visit_id: str, user_id: str) -> Invoice:
+        user = self.users[user_id]
+        self.access_control.assert_access(user.role, UnitType.REVENUE)
+        visit = self.visits[visit_id]
+        invoice = Invoice(invoice_id=invoice_id, visit=visit)
+        self.invoices[invoice_id] = invoice
+        return invoice
+
+    def record_payment(self, invoice_id: str, amount: float, user_id: str) -> Invoice:
+        user = self.users[user_id]
+        self.access_control.assert_access(user.role, UnitType.ACCOUNTS)
+        invoice = self.invoices[invoice_id]
+        invoice.add_payment(amount)
+        return invoice
+
+    def get_visit_summary(self, visit_id: str) -> Dict[str, object]:
+        visit = self.visits[visit_id]
+        return {
+            "patient": visit.patient.name,
+            "services": [service.description for service in visit.services],
+            "medications": [order.medication for order in visit.medications],
+            "total_cost": visit.total_cost(),
+        }
+
+    def report_by_unit(self, unit: UnitType) -> Dict[str, float]:
+        """Aggregate revenue for services performed by a unit."""
+
+        total = 0.0
+        service_count = 0
+        for visit in self.visits.values():
+            for service in visit.services:
+                if service.unit == unit:
+                    total += service.cost
+                    service_count += 1
+        return {"unit": unit.value, "total_revenue": total, "services_rendered": service_count}
+
+    @classmethod
+    def with_default_policy(cls) -> "HospitalManagementSystem":
+        policy = {
+            UnitType.RECORDS: {Role.ADMIN, Role.RECORDS_CLERK},
+            UnitType.REVENUE: {Role.ADMIN, Role.ACCOUNTANT},
+            UnitType.ACCOUNTS: {Role.ADMIN, Role.ACCOUNTANT},
+            UnitType.NURSING: {Role.ADMIN, Role.NURSE},
+            UnitType.WARDS: {Role.ADMIN, Role.NURSE},
+            UnitType.MATERNITY: {Role.ADMIN, Role.NURSE, Role.DOCTOR},
+            UnitType.EYE: {Role.ADMIN, Role.DOCTOR},
+            UnitType.ADOLESCENT_HEALTH: {Role.ADMIN, Role.DOCTOR, Role.NURSE},
+            UnitType.MENTAL_HEALTH: {Role.ADMIN, Role.DOCTOR},
+            UnitType.FAMILY_PLANNING: {Role.ADMIN, Role.DOCTOR, Role.NURSE},
+            UnitType.LABORATORY: {Role.ADMIN, Role.LAB_TECH},
+            UnitType.PHARMACY: {Role.ADMIN, Role.PHARMACIST},
+            UnitType.DISPENSARY: {Role.ADMIN, Role.PHARMACIST},
+            UnitType.DOCTORS: {Role.ADMIN, Role.DOCTOR},
+        }
+        system = cls(access_control=AccessControl(policy=policy))
+        for unit_type in UnitType:
+            system.register_unit(Unit(unit_type=unit_type, name=unit_type.value))
+        return system
+
+    def assign_user_to_unit(self, user_id: str, unit: UnitType) -> None:
+        user = self.users[user_id]
+        user.assigned_units.add(unit)
+
+    def find_patient(self, patient_id: str) -> Optional[Patient]:
+        return self.patients.get(patient_id)
+
+    def list_units(self) -> List[str]:
+        return [unit.value for unit in UnitType]
+
+    def list_roles(self) -> List[str]:
+        return [role.name for role in Role]

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+import pytest
+
+from hospital_management.models import Patient, Role, UnitType, User
+from hospital_management.system import HospitalManagementSystem
+
+
+def build_system():
+    system = HospitalManagementSystem.with_default_policy()
+    system.add_user(User(user_id="clerk", name="Records", role=Role.RECORDS_CLERK))
+    system.add_user(User(user_id="doctor", name="Doctor", role=Role.DOCTOR))
+    system.add_user(User(user_id="nurse", name="Nurse", role=Role.NURSE))
+    system.add_user(User(user_id="labtech", name="Lab Tech", role=Role.LAB_TECH))
+    system.add_user(User(user_id="pharm", name="Pharmacist", role=Role.PHARMACIST))
+    system.add_user(User(user_id="accountant", name="Accountant", role=Role.ACCOUNTANT))
+
+    patient = Patient(patient_id="p1", name="Test Patient", date_of_birth=datetime(1990, 1, 1))
+    system.register_patient(patient)
+    return system, patient
+
+
+def test_visit_and_invoice_flow():
+    system, patient = build_system()
+
+    visit = system.start_visit("v1", patient.patient_id, user_id="clerk")
+    system.record_service(visit.visit_id, "Ward admission", UnitType.WARDS, 100.0, user_id="nurse")
+    system.record_service(visit.visit_id, "Doctor consult", UnitType.DOCTORS, 75.0, user_id="doctor")
+    system.record_medication(visit.visit_id, "Painkiller", "10mg", 10, UnitType.PHARMACY, 20.0, user_id="pharm")
+
+    invoice = system.create_invoice("inv1", visit.visit_id, user_id="accountant")
+    assert invoice.total_due == pytest.approx(195.0)
+
+    system.record_payment(invoice.invoice_id, 195.0, user_id="accountant")
+    assert invoice.paid
+    assert invoice.balance == pytest.approx(0.0)
+
+
+def test_permission_enforced():
+    system, patient = build_system()
+    system.start_visit("v1", patient.patient_id, user_id="clerk")
+
+    with pytest.raises(PermissionError):
+        system.create_invoice("inv1", "v1", user_id="doctor")
+
+
+def test_report_by_unit():
+    system, patient = build_system()
+    visit = system.start_visit("v1", patient.patient_id, user_id="clerk")
+    system.record_service(visit.visit_id, "Lab test", UnitType.LABORATORY, 40.0, user_id="labtech")
+    system.record_service(visit.visit_id, "Family planning", UnitType.FAMILY_PLANNING, 25.0, user_id="doctor")
+
+    lab_report = system.report_by_unit(UnitType.LABORATORY)
+    assert lab_report["total_revenue"] == pytest.approx(40.0)
+    assert lab_report["services_rendered"] == 1
+
+    fp_report = system.report_by_unit(UnitType.FAMILY_PLANNING)
+    assert fp_report["total_revenue"] == pytest.approx(25.0)


### PR DESCRIPTION
## Summary
- add an in-memory hospital management system with role-based permissions for clinical and administrative units
- include demo workflow covering registration, services, medications, invoicing, and revenue reporting
- add automated tests for visit flow, permission enforcement, and unit revenue reporting

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693954cbd13c8325b27507c45e0c3592)